### PR TITLE
Use https and fix error message

### DIFF
--- a/src/GifSearch.js
+++ b/src/GifSearch.js
@@ -15,7 +15,7 @@ import {
 
 import Requests from './Requests';
 
-const BASE_URL = 'http://api.giphy.com/v1/gifs/';
+const BASE_URL = 'https://api.giphy.com/v1/gifs/';
 
 class GifSearch extends PureComponent {
 

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -21,7 +21,7 @@ export default class Requests {
 
                 }
                 if (xhr.readyState === XMLHttpRequest.DONE && xhr.status == 0){
-                    reject("No interner")
+                    reject("No internet or request failed")
                 }
 
             }


### PR DESCRIPTION
It's a good idea to use https instead of http.
I also fixed a little type in the error message when a request fails and made the error a bit more accurate.