### PR TITLE
Fixes missing state variable for `numColumns` prop

### DIFF
--- a/src/GifSearch.js
+++ b/src/GifSearch.js
@@ -88,7 +88,7 @@ class GifSearch extends PureComponent {
       if (props.numColumns != null) {
           this.numColumns = props.numColumns;
           this.horizontal = false;
-          this.state.gifSize = Dimensions.get('window').width / this.numColumns - 20;
+          this.gifSize = Dimensions.get('window').width / this.numColumns - 20;
       }
       this.provider = providers.ALL;
       if (props.provider != null) {
@@ -136,6 +136,7 @@ class GifSearch extends PureComponent {
         gifsOver: false,
         noGifsFound: false,
         next: 0,
+        gifSize: this.gifSize,
       }
 
   }


### PR DESCRIPTION
While trying to get two-columns view, I was getting this error message.
```
my-app\node_modules\react-native\Libraries\Core\ExceptionsManager.js:179 TypeError: Cannot set property 'gifSize' of undefined

This error is located at:
    in GifSearch
```

*I have inferred that this is just due to a missing state variable definition in `GifSearch.js`. Presented fix solves the issue locally for me. I hope it helps the lib!*

P.S. Hey there, thanks for all good work in creating this SDK, really useful ::)