### PR TITLE
[ENHANCE] Preview Quality Prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.tgz
-example/android/local.properties
+android/local.properties
 node_modules
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.tgz
-android/local.properties
-node_modules/
+example/android/local.properties
+node_modules
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Usage examples: [JS code](Examples/js-example/App.js), [TS code](Examples/ts-exa
 | `showStickersButtonSelectedTextStyle` | No | Additional style for the text of the button that shows stickers when the button is selected and `gifType` is `"all"`. | |
 | `showStickersButtonStyle` | No | Additional style for the button that shows stickers when `gifType` is `"all"`. | |
 | `showStickersButtonSelectedStyle` | No | Additional style for the button that shows stickers when it is selected and `gifType` is `"all"`. | |
-| `giphyPreviewQuality` | No | Additional parameter to select Giphy preview source media type. Please refer to [Giphy Images Object](https://developers.giphy.com/docs/api/schema#image-object).  | |
-| `tenorPreviewQuality` | No | Additional parameter to select Tenor preview source media type. Please refer to [Tenor GIF Formats](https://tenor.com/gifapi/documentation#responseobjects-gifformat). | |
+| `previewGifQuality` | No | Additional parameter to choose GIF preview source media type. | |
+| `selectedGifQuality` | No | Additional parameter to choose GIF selected source media type. | |
 
 ## Attribution
 If you wish to **publish your app** and go from development to production you need to follow some steps for every API that you use.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Usage examples: [JS code](Examples/js-example/App.js), [TS code](Examples/ts-exa
 | `showStickersButtonSelectedTextStyle` | No | Additional style for the text of the button that shows stickers when the button is selected and `gifType` is `"all"`. | |
 | `showStickersButtonStyle` | No | Additional style for the button that shows stickers when `gifType` is `"all"`. | |
 | `showStickersButtonSelectedStyle` | No | Additional style for the button that shows stickers when it is selected and `gifType` is `"all"`. | |
-
+| `giphyPreviewQuality` | No | Additional parameter to select Giphy preview source media type. Please refer to [Giphy Images Object](https://developers.giphy.com/docs/api/schema#image-object).  | |
+| `tenorPreviewQuality` | No | Additional parameter to select Tenor preview source media type. Please refer to [Tenor GIF Formats](https://tenor.com/gifapi/documentation#responseobjects-gifformat). | |
 
 ## Attribution
 If you wish to **publish your app** and go from development to production you need to follow some steps for every API that you use.

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,6 +179,8 @@ declare module 'react-native-gif-search' {
     showStickersButtonText?: string;
     placeholderTextColor?: string;
     loadingSpinnerColor?: string;
+    giphyPreviewQuality?: keyof GiphyImages;
+    tenorPreviewQuality?: keyof TenorGifFormats;
 
     style?: ViewStyle;
     textInputStyle?: TextStyle;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,8 @@ declare module 'react-native-gif-search' {
 
   type Rating = "y" | "g" | "pg" | "pg-13" | "r";
 
+  type MediaFormats = "low" | "medium" | "high";
+
   interface GiphyImages {
     fixed_height: BaseImage & {
       size: string;
@@ -179,8 +181,8 @@ declare module 'react-native-gif-search' {
     showStickersButtonText?: string;
     placeholderTextColor?: string;
     loadingSpinnerColor?: string;
-    giphyPreviewQuality?: keyof GiphyImages;
-    tenorPreviewQuality?: keyof TenorGifFormats;
+    previewGifQuality?: MediaFormats;
+    selectedGifQuality?: MediaFormats;
 
     style?: ViewStyle;
     textInputStyle?: TextStyle;

--- a/src/GifSearch.js
+++ b/src/GifSearch.js
@@ -35,6 +35,18 @@ const endpoints = {
   SEARCH: "search",
 }
 
+const giphyFormats = {
+    low: "preview_gif",
+    medium: "fixed_width",
+    high: "downsized_large"
+}
+
+const tenorFormats = {
+    low: "nanogif",
+    medium: "tinygif",
+    high: "mediumgif"
+}
+
 class GifSearch extends PureComponent {
 
     constructor(props) {
@@ -124,15 +136,21 @@ class GifSearch extends PureComponent {
           this.provider = providers.GIPHY
       }
 
-      this.giphyPreviewQuality = "preview_gif";
-      if (props.giphyPreviewQuality != null) {
-          this.giphyPreviewQuality = props.giphyPreviewQuality;
+      this.previewGifQuality = "low";
+      if (props.previewGifQuality != null) {
+          this.previewGifQuality = props.previewGifQuality;
       }
 
-      this.tenorPreviewQuality = "nanogif";
-      if (props.tenorPreviewQuality != null) {
-          this.tenorPreviewQuality = props.tenorPreviewQuality;
+      this.selectedGifQuality = "medium";
+      if (props.selectedGifQuality != null) {
+          this.selectedGifQuality = props.selectedGifQuality;
       }
+
+      this.tenorGifPreview = tenorFormats[this.previewGifQuality];
+      this.tenorGifSelected = tenorFormats[this.selectedGifQuality];
+
+      this.giphyGifPreview = giphyFormats[this.previewGifQuality];
+      this.giphyGifSelected = giphyFormats[this.selectedGifQuality];
             
       this.state = {
         gifs: [],
@@ -233,7 +251,6 @@ class GifSearch extends PureComponent {
               "key": this.tenorApiKey,
               "limit": limit,
               "locale": "el_GR",
-              "media_filter": "basic",
               "contentfilter": "medium",
               ...this.state.next != 0 && {"pos": this.state.next},
               ...this.props.tenorApiProps,
@@ -455,16 +472,16 @@ class GifSearch extends PureComponent {
               var gif_better_quality = null;
 
               if (item.provider == providers.TENOR) {
-                gif_preview = item.media[0][this.tenorPreviewQuality].url
-                gif_better_quality = item.media[0].tinygif.url
-                if (parseInt(item.media[0].tinygif.dims[1])) {
-                    aspect_ratio = parseInt(item.media[0].tinygif.dims[0])/parseInt(item.media[0].tinygif.dims[1])
+                gif_preview = item.media[0][this.tenorGifPreview].url
+                gif_better_quality = item.media[0][this.tenorGifSelected].url
+                if (parseInt(item.media[0][this.tenorGifSelected].dims[1])) {
+                    aspect_ratio = parseInt(item.media[0][this.tenorGifSelected].dims[0])/parseInt(item.media[0][this.tenorGifSelected].dims[1])
                 }
               } else {
-                gif_preview = item.images[this.giphyPreviewQuality].url
-                gif_better_quality = item.images.downsized.url
-                if (parseInt(item.images[this.giphyPreviewQuality].height)) {
-                    aspect_ratio = parseInt(item.images[this.giphyPreviewQuality].width)/parseInt(item.images[this.giphyPreviewQuality].height)
+                gif_preview = item.images[this.giphyGifPreview].url
+                gif_better_quality = item.images[this.giphyGifSelected].url
+                if (parseInt(item.images[this.giphyGifSelected].height)) {
+                    aspect_ratio = parseInt(item.images[this.giphyGifSelected].width)/parseInt(item.images[this.giphyGifSelected].height)
                 }
               }
 

--- a/src/GifSearch.js
+++ b/src/GifSearch.js
@@ -123,6 +123,16 @@ class GifSearch extends PureComponent {
       if (currentGifType == gif_types.STICKER) {
           this.provider = providers.GIPHY
       }
+
+      this.giphyPreviewQuality = "preview_gif";
+      if (props.giphyPreviewQuality != null) {
+          this.giphyPreviewQuality = props.giphyPreviewQuality;
+      }
+
+      this.tenorPreviewQuality = "nanogif";
+      if (props.tenorPreviewQuality != null) {
+          this.tenorPreviewQuality = props.tenorPreviewQuality;
+      }
             
       this.state = {
         gifs: [],
@@ -445,16 +455,16 @@ class GifSearch extends PureComponent {
               var gif_better_quality = null;
 
               if (item.provider == providers.TENOR) {
-                gif_preview = item.media[0].nanogif.url
+                gif_preview = item.media[0][this.tenorPreviewQuality].url
                 gif_better_quality = item.media[0].tinygif.url
                 if (parseInt(item.media[0].tinygif.dims[1])) {
                     aspect_ratio = parseInt(item.media[0].tinygif.dims[0])/parseInt(item.media[0].tinygif.dims[1])
                 }
               } else {
-                gif_preview = item.images.preview_gif.url
+                gif_preview = item.images[[this.giphyPreviewQuality]].url
                 gif_better_quality = item.images.downsized.url
-                if (parseInt(item.images.preview_gif.height)) {
-                    aspect_ratio = parseInt(item.images.preview_gif.width)/parseInt(item.images.preview_gif.height)
+                if (parseInt(item.images[[this.giphyPreviewQuality]].height)) {
+                    aspect_ratio = parseInt(item.images[[this.giphyPreviewQuality]].width)/parseInt(item.images[[this.giphyPreviewQuality]].height)
                 }
               }
 

--- a/src/GifSearch.js
+++ b/src/GifSearch.js
@@ -461,10 +461,10 @@ class GifSearch extends PureComponent {
                     aspect_ratio = parseInt(item.media[0].tinygif.dims[0])/parseInt(item.media[0].tinygif.dims[1])
                 }
               } else {
-                gif_preview = item.images[[this.giphyPreviewQuality]].url
+                gif_preview = item.images[this.giphyPreviewQuality].url
                 gif_better_quality = item.images.downsized.url
-                if (parseInt(item.images[[this.giphyPreviewQuality]].height)) {
-                    aspect_ratio = parseInt(item.images[[this.giphyPreviewQuality]].width)/parseInt(item.images[[this.giphyPreviewQuality]].height)
+                if (parseInt(item.images[this.giphyPreviewQuality].height)) {
+                    aspect_ratio = parseInt(item.images[this.giphyPreviewQuality].width)/parseInt(item.images[this.giphyPreviewQuality].height)
                 }
               }
 


### PR DESCRIPTION
GIF stills in a **lower quality** in preview mode.
So the goal of this PR is to let user to choose its own media type for preview with the props **`giphyPreviewQuality`** & **`tenorPreviewQuality`**.

See the example below.
Left with **`preview_gif`** media type and right with **`fixed_width`** media type from Giphy.
You can see a better quality on the right side.

@Thanasis1101 say me what do you think about it ?

<img width="1063" alt="Capture d’écran 2021-04-06 à 13 52 04" src="https://user-images.githubusercontent.com/28066214/113706783-5ef63800-96df-11eb-9801-39bcc51c1d66.png">
