### PR TITLE
Resolving typescript issues for gifType and Providers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,12 +7,16 @@ declare module 'react-native-gif-search' {
     GIPHY = 'giphy',
     ALL = 'all',
   }
+  
+  type Provider = `${Providers}`;
 
   enum GifTypes {
     GIF = 'gif',
     STICKER = 'sticker',
     ALL = 'all',
   }
+  
+  type GifType = `${GifTypes}`;
 
   interface BaseImage {
     url: string;
@@ -174,9 +178,9 @@ declare module 'react-native-gif-search' {
     noGifsFoundText?: string;
     horizontal?: boolean;
     numColumns?: number;
-    provider?: keyof typeof Providers;
+    provider?: Provider;
     providerLogo?: string;
-    gifType?: keyof typeof GifTypes;
+    gifType?: GifType;
     showGifsButtonText?: string;
     showStickersButtonText?: string;
     placeholderTextColor?: string;


### PR DESCRIPTION
Updated types for typescript compatibility.  We were getting an issue with the values not allowing strings and not correctly receiving the enum types appropriately so this change ensures that the types are based on the values of the types rather than the keys.

The keys are still compatible since they convert down to strings. 

We've been running this in production since July 15th with no issues.

Please let me know if I overlooked something, obviously this change was created to push us past a blocker, but its been operating fairly stable for over a month.